### PR TITLE
Handle missing methods for resource type properties

### DIFF
--- a/lib/puppet/type/purge.rb
+++ b/lib/puppet/type/purge.rb
@@ -172,7 +172,11 @@ Puppet::Type.newtype(:purge) do
 
     ## Don't purge things that are already in sync
     resource_instances = resource_instances.reject { |r|
-      is = r.property(manage_property).retrieve
+      is = begin
+             r.property(manage_property).retrieve
+           rescue NoMethodError
+             r.to_hash[manage_property]
+           end
       should = is.is_a?(Symbol) ? state.to_sym : state
       is == should
     }


### PR DESCRIPTION
If unable to #retrieve a resource type property, fallback to a #to_hash
key named after the property.

Handles "undefined method `<property name>' for nil:NilClass"
exceptions.