### PR TITLE
Use `resource.retrieve` for Puppet Resource API compatibility

### DIFF
--- a/lib/puppet/type/purge.rb
+++ b/lib/puppet/type/purge.rb
@@ -172,7 +172,7 @@ Puppet::Type.newtype(:purge) do
 
     ## Don't purge things that are already in sync
     resource_instances = resource_instances.reject { |r|
-      is = r.property(manage_property).retrieve
+      is = r.retrieve
       should = is.is_a?(Symbol) ? state.to_sym : state
       is == should
     }


### PR DESCRIPTION
`resource.property(name).retrieve` requires a provider that uses
`mk_resource_methods` or equivalent, which is not the case with the
Puppet Resource API.

`resource.retrieve` should be implemented across all types.

Thanks @DavidS for the suggestion.